### PR TITLE
feat: Update actions to use Node.js 16:

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Install the preferred version of Terraform CLI
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.0.10
+          terraform_version: 1.1.7
 
       # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
       - name: Terraform Init


### PR DESCRIPTION
- updated to actions/checkout@v3 from actions/checkout@v2
- updated to hashicorp/setup-terraform@v2 from hashicorp/setup-terraform@v1
- updated terraform version to 1.1.7 from 1.0.10