### PR TITLE
feat: Re arrange deployment order and made pipeline enhancements

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,7 +39,7 @@ jobs:
           CONTAINER_NAME: ${{ secrets.CONTAINER_NAME }}
         run: terraform init -backend-config="storage_account_name=$STORAGE_ACCOUNT" -backend-config="container_name=$CONTAINER_NAME" -backend-config="resource_group_name=$RESOURCE_GROUP"
 
-      # Run a terraform plan for pull requests only
+      # Run a terraform plan for pull requests and pushes
       - name: Terraform Plan
         id: plan
         env:
@@ -47,9 +47,10 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event_name == 'push'
         run: terraform plan -no-color
 
+      # Run terraform Apply on push to main
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         env:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,30 +1,35 @@
 # locals
 locals {
   test_resource_group   = "rg-${var.naming_prefix}-test-${var.location}-01"
-  test_static_front_end = "stapp-frontend-${var.naming_prefix}-test-${var.location}-01"
   prod_resource_group   = "rg-${var.naming_prefix}-prod-${var.location}-01"
+  test_static_front_end = "stapp-frontend-${var.naming_prefix}-test-${var.location}-01"
   prod_static_front_end = "stapp-frontend-${var.naming_prefix}-prod-${var.location}-01"
 }
 
 # resources
+
+# resource groups:
 resource "azurerm_resource_group" "test_rg" {
   name     = local.test_resource_group
   location = var.location
   tags     = var.test_tags
 }
 
+resource "azurerm_resource_group" "prod_rg" {
+  name     = local.prod_resource_group
+  location = var.location
+  tags     = var.prod_tags
+}
+
+
+
+# static web apps:
 resource "azurerm_static_site" "test_static_front_end" {
   name                = local.test_static_front_end
   resource_group_name = local.test_resource_group
   location            = var.location
   sku_tier            = "Free"
   sku_size            = "Free"
-}
-
-resource "azurerm_resource_group" "prod_rg" {
-  name     = local.prod_resource_group
-  location = var.location
-  tags     = var.prod_tags
 }
 
 resource "azurerm_static_site" "prod_static_front_end" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,6 @@
 # vars
+
+# tags
 variable "test_tags" {
   type = map(string)
   default = {
@@ -15,6 +17,7 @@ variable "prod_tags" {
   }
 }
 
+# constant values
 variable "location" {
   type    = string
   default = "centralus"


### PR DESCRIPTION
- re arrange deployments so that all the resource types are grouped by their kind.
- - rgs get deployed first, then other resources.
- - test environment gets deployed before prod.
- enhance deployment terraform pipeline to run terraform plan also on push to main.